### PR TITLE
Clean out MIDI notes

### DIFF
--- a/tidbit.lua
+++ b/tidbit.lua
@@ -197,7 +197,7 @@ function init()
   
   local voice_options = {"jf", "w/synth", "jf & wsynth", "midi"}
   params:add_option("voices","voices",voice_options, 1)
-  params:add_number("midi_dev", "midi device", 1, 4, 1)
+  params:add_number("midi_dev", "midi device", 1, 16, 1)
   params:hide("midi_dev")
   params:add_number("midi_ch", "midi channel", 1, 16, 1)
   params:hide("midi_ch")
@@ -417,7 +417,7 @@ end
 
 function midi_stop_all_notes()
    local midi_dev = midi.connect(params:get("midi_dev"))
-   print("Stopping all notes on "..midi_dev.name)
+   print("stopping all notes on "..midi_dev.name)
    -- Stop all notes MIDI channel mode message.
    -- https://www.midi.org/specifications-old/item/table-3-control-change-messages-data-bytes-2
    midi_dev:cc(123, 0, params:get("midi_ch"))

--- a/tidbit.lua
+++ b/tidbit.lua
@@ -359,7 +359,6 @@ function strum()
     elseif selected_voice == 2 then
       crow.ii.wsyn.play_note((notes[noteSet][note]/12-1)+tune,math.random(10)*noteAmps[noteSet][note])
 
-    
     elseif selected_voice == 3 then
       local randomNumber = math.random(100)
       if randomNumber < voice_chance then
@@ -374,13 +373,11 @@ function strum()
       midi_amp = util.round(util.linlin(0, 10, 0, 127, math.random(10)*noteAmps[noteSet][note]))
       midi_dev:note_on(midi_note, midi_amp, params:get("midi_ch"))
 
+    end
     -- send current note and redraw
     noteForDrawing = notes[noteSet][note]
     ampForDrawing = noteAmps[noteSet][note]
     redraw()
-    end
-    
-    
     
     -- for testing w/ polyperc
     -- engine.amp(math.random(1)*noteAmps[noteSet][note])
@@ -388,7 +385,6 @@ function strum()
     
     -- for the screen
     -- do something cool with a slider with flickering bits on it
-    
     
     redraw()
   end

--- a/tidbit.lua
+++ b/tidbit.lua
@@ -203,16 +203,22 @@ function init()
   params:hide("midi_ch")
   _menu.rebuild_params()
   params:set_action("voices", function(x)
-		       selected_voice = x
-		       if voice_options[x] == "midi" then
-			  params:show("midi_dev")
-			  params:show("midi_ch")
-			  _menu.rebuild_params()
-		       else
-			  params:hide("midi_dev")
-			  params:hide("midi_ch")
-			  _menu.rebuild_params()
-		       end
+                       -- Unselecting MIDI, so stop all notes.
+                       if selected_voice == 4 and x ~= 4 then
+                          midi_stop_all_notes()
+                       end
+
+                       selected_voice = x
+
+                       if voice_options[x] == "midi" then
+                          params:show("midi_dev")
+                          params:show("midi_ch")
+                          _menu.rebuild_params()
+                       else
+                          params:hide("midi_dev")
+                          params:hide("midi_ch")
+                          _menu.rebuild_params()
+                       end
   end)
   selected_voice = 1
 
@@ -374,11 +380,12 @@ function strum()
       midi_dev:note_on(midi_note, midi_amp, params:get("midi_ch"))
 
     end
+
     -- send current note and redraw
     noteForDrawing = notes[noteSet][note]
     ampForDrawing = noteAmps[noteSet][note]
     redraw()
-    
+
     -- for testing w/ polyperc
     -- engine.amp(math.random(1)*noteAmps[noteSet][note])
     -- engine.hz(midi_to_hz(48+(notes[noteSet][note]/12-1)+tune))
@@ -406,4 +413,21 @@ end
 function midi_to_hz(note) -- this is only here for the polyperc engine test
   local hz = (440 / 32) * (2 ^ ((note - 9) / 12))
   return hz
+end
+
+function midi_stop_all_notes()
+   local midi_dev = midi.connect(params:get("midi_dev"))
+   print("Stopping all notes on "..midi_dev.name)
+   -- Stop all notes MIDI channel mode message.
+   -- https://www.midi.org/specifications-old/item/table-3-control-change-messages-data-bytes-2
+   midi_dev:cc(123, 0, params:get("midi_ch"))
+
+   -- Loop over all notes and stop them.
+   for note_num=0,127,1 do
+      midi_dev:note_off(midi_note, 0, params:get("midi_ch"))
+   end
+end
+
+function cleanup()
+   midi_stop_all_notes()
 end


### PR DESCRIPTION
Hi. There was some [discussion on the forum](https://llllllll.co/t/tidbit/52104/46) about management of stuck MIDI notes). When I first created the MIDI implementation I considered it a non-issue, thinking that stuck MIDI notes are the name of the game, and that voice stealing will take care of it... similar to the _JF_ implemetation if I understand correctly. However it leaves the devices in unstable state even after loading another script, so I tried to change the implementation so that the MIDI notes are reset when either the user chooses other voices than MIDI within Tidbit, or loads another script. This leaves it possible to put to use features like looping envelopes, ARPs, infinite releases etc on MIDI devices themselves, and is hopefully in line with the behaviour of original JF, w/ etc. voices which don't trigger a "note off" kind of event either, forcing a note length from Tidbit but leave it to the device.

Please don't hesitate to let me know if this does not seem ok, if something can be more robust, clearer etc.

Sorry for reusing the branch, I am not so great with git.